### PR TITLE
Enabled advanced query for supported games

### DIFF
--- a/main_bot.py
+++ b/main_bot.py
@@ -94,6 +94,8 @@ async def status(ctx):
     for title, game in game_library.items():
         if game.active:
             status = '**online**'
+            if game.has_query:
+                await ctx.send(server_command.query_server(game))
         else:
             status = '**offline**'
         output = output + f'{game.title} server is currently {status} \n'


### PR DESCRIPTION
If game is said to support advanced query in config, it will use the minecraft query function in order to determine number of players online